### PR TITLE
chore(deps): update Dockerfile to Ruby 3.2 / Alpine 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ruby:2.7.5-alpine3.15
+FROM ruby:3.2.2-alpine3.18
 
 RUN apk add --update --no-cache git openssh bash github-cli
 RUN gem update --system
-RUN gem install bundler -v '~>2.1'
+RUN gem install bundler -v '~>2.4'
 
 RUN mkdir -p home
 WORKDIR home


### PR DESCRIPTION
Released as `v0.1.0`

https://github.com/pact-foundation/release-gem/releases/tag/v0.1.0

Previous tag `v0.0.14` using ruby 2 / Alpine 3.18 / Bundler 2.1 - https://github.com/pact-foundation/release-gem/releases/tag/v0.0.14